### PR TITLE
Data array was populating more than necessary

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -14,7 +14,8 @@ with open('token', 'r') as token_file:
 founds, data	= [], []
 for line in in_file:
     founds.append(line.rstrip())
-    data = {u"key": token, u"found": founds }
+
+data = {u"key": token, u"found": founds}
 
 response = requests.post(baseurl, json.dumps(data))
 print response.content


### PR DESCRIPTION
The source array for the JSON dump is now only generated once, after all the 'founds' are read in. I figured this was just a typo in the original, but for anyone pushing a lot submissions in a batch this was worth addressing :)